### PR TITLE
feat: multi-stage Dockerfile + default port 8019

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Build artifacts
+bin/
+coverage/
+web/dist/
+web/node_modules/
+
+# Database files
+*.db
+*.db-shm
+*.db-wal
+
+# IDE / OS
+.idea/
+.vscode/
+*.swp
+.DS_Store
+
+# Git
+.git/
+.github/
+
+# Dev tools
+deploy/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# ---- Stage 1: Build frontend ----
+FROM node:24-slim AS frontend
+
+WORKDIR /src/web
+
+# Enable Corepack so pnpm is available at the pinned version.
+RUN corepack enable
+
+# Install dependencies first (layer cache).
+COPY web/package.json web/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build production bundle → dist/
+COPY web/ ./
+RUN pnpm build
+
+# ---- Stage 2: Build Go binary ----
+FROM golang:1.25 AS backend
+
+WORKDIR /src
+
+# Download Go modules first (layer cache).
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and the frontend bundle from stage 1.
+COPY . .
+COPY --from=frontend /src/web/dist ./web/dist
+
+# Build a fully static binary (pure Go, no CGO needed — uses modernc.org/sqlite).
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /tenantiq ./cmd/tenantiq
+
+# ---- Stage 3: Minimal runtime ----
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=backend /tenantiq /tenantiq
+
+EXPOSE 8019
+
+ENTRYPOINT ["/tenantiq"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test cover lint clean dev dev-otel fmt vet setup otel otel-stop help web web-dev web-api web-install
+.PHONY: all build test cover lint clean dev dev-otel fmt vet setup otel otel-stop help web web-dev web-api web-install image
 .DEFAULT_GOAL := help
 
 # --- Config ---
@@ -99,14 +99,19 @@ web: ## Build frontend for production
 	@echo "==> Building frontend..."
 	cd web && pnpm build
 
-web-dev: ## Run frontend dev server (proxies API to :8080)
+web-dev: ## Run frontend dev server (proxies API to :8019)
 	cd web && pnpm dev
 
 web-api: ## Regenerate API client from OpenAPI spec (server must be running)
 	@echo "==> Generating API client from OpenAPI spec..."
-	curl -sf http://localhost:8080/openapi.json -o web/openapi.json
+	curl -sf http://localhost:8019/openapi.json -o web/openapi.json
 	cd web && pnpm api:generate
 	@echo "==> API client updated."
+
+# --- Container ---
+image: ## Build container image (uses podman or docker)
+	@echo "==> Building container image..."
+	$(CONTAINER) build -t $(BINARY) .
 
 # --- Cleanup ---
 clean: ## Remove build artifacts

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ go build -o tenantiq ./cmd/tenantiq
 # Run
 ./tenantiq
 
-# The API will be available at http://localhost:8080
-# OpenAPI docs at http://localhost:8080/docs
+# The API will be available at http://localhost:8019
+# OpenAPI docs at http://localhost:8019/docs
 ```
 
 ## API Overview
@@ -85,7 +85,7 @@ tenantiq uses environment variables for configuration:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `8080` | HTTP server port |
+| `PORT` | `8019` | HTTP server port |
 | `DATABASE_PATH` | `tenantiq.db` | SQLite database file path |
 | `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 

--- a/cmd/tenantiq/main.go
+++ b/cmd/tenantiq/main.go
@@ -37,7 +37,7 @@ func main() {
 }
 
 func run() error {
-	port := envOrDefault("PORT", "8080")
+	port := envOrDefault("PORT", "8019")
 	dbPath := envOrDefault("DATABASE_PATH", "tenantiq.db")
 	jwtSecret := envOrDefault("TENANTIQ_JWT_SECRET", "")
 	adminEmail := envOrDefault("TENANTIQ_ADMIN_EMAIL", "admin@tenantiq.local")

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:8080",
-      "/openapi.json": "http://localhost:8080",
+      "/api": "http://localhost:8019",
+      "/openapi.json": "http://localhost:8019",
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile: Node 24 (frontend) → Go 1.25 (backend) → distroless (runtime), producing a ~26MB image
- Add `.dockerignore` to keep build context minimal
- Add `make image` target (auto-detects podman/docker)
- Change default port from 8080 to 8019 across all config, docs, and dev tooling

## Details

- **CGO_ENABLED=0** — possible because we use `modernc.org/sqlite` (pure Go)
- **distroless/static-debian12** — includes CA certs and tzdata, no shell (~2MB more than scratch)
- **Layer caching** optimized: dependency files copied before source code
- Smoke tested locally: image builds, starts, runs migrations, and serves API correctly

## Test plan

- [x] `make image` builds successfully
- [x] Container starts and runs SQLite migrations
- [x] `/api/v1/auth/me` returns 401 (correct, no token)
- [ ] CI passes on PR

Closes #4