### PR TITLE
feat: automatic token refresh on 401

### DIFF
--- a/web/src/lib/axios.ts
+++ b/web/src/lib/axios.ts
@@ -1,4 +1,8 @@
-import Axios, { type AxiosRequestConfig, type AxiosError } from "axios";
+import Axios, {
+  type AxiosRequestConfig,
+  type AxiosError,
+  type InternalAxiosRequestConfig,
+} from "axios";
 
 export const axios = Axios.create({
   baseURL: "",
@@ -21,7 +25,9 @@ function drainQueue(error: AxiosError | null) {
 }
 
 axios.interceptors.response.use(undefined, async (error: AxiosError) => {
-  const original = error.config;
+  const original = error.config as InternalAxiosRequestConfig & {
+    _retried?: boolean;
+  };
   if (!original || error.response?.status !== 401) return Promise.reject(error);
 
   // Don't intercept auth endpoints — avoids infinite loops.
@@ -34,11 +40,17 @@ axios.interceptors.response.use(undefined, async (error: AxiosError) => {
     return Promise.reject(error);
   }
 
+  // Already retried after refresh — don't loop.
+  if (original._retried) return Promise.reject(error);
+
   // If a refresh is already in flight, queue this request.
   if (isRefreshing) {
     return new Promise((resolve, reject) => {
       pendingQueue.push({ resolve, reject });
-    }).then(() => axios(original));
+    }).then(() => {
+      original._retried = true;
+      return axios(original);
+    });
   }
 
   isRefreshing = true;
@@ -46,6 +58,7 @@ axios.interceptors.response.use(undefined, async (error: AxiosError) => {
   try {
     await axios.post("/api/v1/auth/refresh");
     drainQueue(null);
+    original._retried = true;
     return axios(original);
   } catch (refreshError) {
     drainQueue(refreshError as AxiosError);


### PR DESCRIPTION
## Summary

- Add axios response interceptor that silently refreshes the access token on 401
- Queue concurrent requests during refresh so only one refresh call is made
- Mark retried requests with `_retried` flag to prevent infinite loops
- Auth endpoints (`/auth/me`, `/auth/login`, `/auth/refresh`) are excluded from interception

## How it works

1. API call returns 401 → interceptor calls `POST /api/v1/auth/refresh` (cookie-based)
2. On success → retries the original request with fresh cookies
3. On failure → error propagates, route guard redirects to `/login`
4. Concurrent 401s → only one refresh, all pending requests retry after

## Test plan

- [ ] Login, wait 15+ min, make API call → should refresh silently
- [ ] Open login page without session → loads normally (no loop)
- [ ] Refresh token expired → redirected to login
- [ ] Multiple simultaneous 401s → single refresh call

Closes #3