### PR TITLE
feat: add devcontainer for VS Code and Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "tenantiq",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.25"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24",
+      "installYarn": false,
+      "installBun": false
+    }
+  },
+
+  "postCreateCommand": "corepack enable && make setup",
+
+  "forwardPorts": [8019, 5173],
+  "portsAttributes": {
+    "8019": { "label": "API" },
+    "5173": { "label": "Vite HMR" }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+        "vitest.explorer"
+      ],
+      "settings": {
+        "go.coverOnTestPackage": true,
+        "go.coverOnSave": true,
+        "vitest.rootConfig": "web/vitest.config.ts"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.devcontainer/devcontainer.json` for one-click dev environment setup
- Base image: `devcontainers/base:bookworm` with Go 1.25 and Node 24 as features
- Runs `corepack enable && make setup` on container creation
- Forwards ports 8019 (API) and 5173 (Vite HMR)
- Pre-installs VS Code extensions: Go, ESLint, Tailwind CSS, Vitest

## Usage

- **VS Code**: Open project → "Reopen in Container" (works with Docker and Podman)
- **GitHub Codespaces**: Click "Code" → "Codespaces" → "New codespace"
- **Podman**: Set `"dev.containers.dockerPath": "podman"` in VS Code user settings

## Test plan

- [x] Builds and starts with Podman
- [x] `make setup` runs successfully
- [x] Go and Node tooling available
- [ ] GitHub Codespaces

Closes #6